### PR TITLE
test commit

### DIFF
--- a/docs/cli/commands/files/index.md
+++ b/docs/cli/commands/files/index.md
@@ -6,6 +6,7 @@ sidebar_position: 3
 
 ---
 
+
 This group contains commands to manage files in third-party storage such as Storj.
 
 Most of these commands require a Storj account and SPCTL configured to use it. Refer to the [Set up Storj](/cli/#set-up-storj-access-optional) section to create a bucket and access grants and set up SPCTL.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated spacing in the CLI “files” command documentation by adding a blank line after the front matter. This improves visual consistency and readability across the docs.
  * No content, behavior, or feature changes—purely a formatting adjustment.
  * End users may notice cleaner spacing before the introductory paragraph; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->