### PR TITLE
Rename cli/quick-guide to deploy-app. Add Python example

### DIFF
--- a/docs/cli/Guides/deploy-app/deploy-app-example.md
+++ b/docs/cli/Guides/deploy-app/deploy-app-example.md
@@ -36,7 +36,7 @@ Keep in mind that file locations inside a CVM will differ from a local run:
 - Data (`input.txt`) must be found in one of the `/sp/inputs/input-xxxx` directories.
 - `result.txt` must be placed into `/sp/output` to be available to download once the execution is finished.
 
-1.1. Create an new file named `entrypoint.sh` and add the following code:
+1.1. Create a new file named `entrypoint.sh` and add the following code:
 
 ```sh title="entrypoint.sh"
 #!/bin/sh
@@ -66,7 +66,7 @@ fi
 exec python3 "${SCRIPT_PATH}"
 ```
 
-Create an new file named `Dockerfile` and add the following code:
+Create a new file named `Dockerfile` and add the following code:
 
 ```dockerfile title="Dockerfile"
 FROM ubuntu:22.04

--- a/docs/cli/Guides/deploy-app/deploy-app-example.md
+++ b/docs/cli/Guides/deploy-app/deploy-app-example.md
@@ -1,0 +1,175 @@
+---
+id: "deploy-app-example"
+title: "Example: Python script"
+slug: "/guides/deploy-app/example"
+sidebar_position: 1
+---
+
+This guide serves as an example to the more general [deployment guide](/cli/guides/deploy-app) and shows how to deploy a Python script on Super Protocol without modifying its code.
+
+The [simple script](/files/usd_to_crypto.py) used here as an example calculates how much Bitcoin (BTC) and Ether (ETH) can be bought for given amount in US dollars:
+
+1. Reads the input amount from `input.txt` located in the same directory.
+2. Fetches current prices of BTC and ETH using CoinGecko API.
+3. Calculates how much BTC and ETH can be bought for this amount of USD.
+4. Creates `result.txt` in the same directory and writes the result to it.
+
+In this deployment, the script will be the <a id="solution"><span className="dashed-underline">solution</span></a>, and `input.txt` will be the <a id="data"><span className="dashed-underline">data</span></a>.
+
+## Prerequisites
+
+- Docker
+- [SPCTL](/cli)
+
+### 0. Prepare the files
+
+Create a local directory `usd_to_crypto`. Download the [example script](/files/usd_to_crypto.py) and rename it to `usd_to_crypto.py`.
+
+Create a new file `input.txt` to serve as the data input, and add a number—USD amount, for example, `100000`.
+
+Copy SPCTL and its `config.json` into this directory.
+
+### 1. Prepare the solution
+
+Keep in mind that file locations inside a CVM will differ from a local run:
+
+- Data (`input.txt`) must be found in one of the `/sp/inputs/input-xxxx` directories.
+- `result.txt` must be placed into `/sp/output` to be available to download once the execution is finished.
+
+1.1. Create an new file named `entrypoint.sh` and add the following code:
+
+```sh title="entrypoint.sh"
+#!/bin/sh
+set -eu
+
+# Fixed CVM paths (overridable if needed)
+: "${INPUTS_DIR:=/sp/inputs}"
+: "${OUTPUT_DIR:=/sp/output}"
+: "${SCRIPT_PATH:=/usr/local/bin/usd_to_crypto.py}"
+
+mkdir -p "${OUTPUT_DIR}"
+cd "${OUTPUT_DIR}"
+
+# Resolve input file
+INPUT_FILE="$(find "${INPUTS_DIR}" -mindepth 2 -maxdepth 3 -type f -name 'input.txt' 2>/dev/null | sort | head -n 1 || true)"
+
+# Make the script's expected input file available in CWD (/sp/output)
+rm -f input.txt || true
+if [ -n "${INPUT_FILE}" ] && [ -f "${INPUT_FILE}" ]; then
+  cp -f "${INPUT_FILE}" input.txt
+else
+  # If missing, create an empty file so the Python script emits a clean error
+  : > input.txt
+fi
+
+# Run the Python script; it reads ./input.txt and writes ./result.txt here (/sp/output)
+exec python3 "${SCRIPT_PATH}"
+```
+
+Create an new file named `Dockerfile` and add the following code:
+
+```dockerfile title="Dockerfile"
+FROM ubuntu:22.04
+
+# Non-interactive tzdata install
+ENV DEBIAN_FRONTEND=noninteractive
+
+# System deps
+RUN apt-get update && apt-get install -y \
+    python3 \
+    python3-pip \
+    ca-certificates \
+    curl \
+    jq \
+    openssl \
+    tzdata \
+    sed \
+    grep \
+    coreutils \
+ && rm -rf /var/lib/apt/lists/*
+
+# Python deps
+RUN pip3 install --no-cache-dir requests
+
+# Put the scripts where your environment expects executables
+COPY usd_to_crypto.py /usr/local/bin/usd_to_crypto.py
+RUN chmod +x /usr/local/bin/usd_to_crypto.py
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set /sp as workdir (doesn't matter in this case; entrypoint.sh uses /sp/output as workdir)
+WORKDIR /sp
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+```
+
+1.2. Build a Docker image:
+
+```shell
+docker build -t usd_to_crypto .
+```
+
+1.3. Save and archive the image:
+
+```shell
+docker save usd_to_crypto:latest | gzip > usd_to_crypto.tar.gz
+```
+
+1.4. Upload the archive:
+
+```shell
+./spctl files upload usd_to_crypto.tar.gz \
+    --filename usd_to_crypto.tar.gz \
+    --output usd_to_crypto.resource.json
+```
+
+### 2. Prepare data
+
+2.1. Archive the file:
+
+```shell
+tar -czvf input.tar.gz ./input.txt
+```
+
+2.2. Upload the archive:
+
+```shell
+./spctl files upload ./input.tar.gz \
+--filename input.tar.gz \
+--output input.resource.json
+```
+
+### 3. Deploy
+
+Place an order:
+
+```shell
+./spctl workflows create \
+--tee 7 \
+--solution ./usd_to_crypto.resource.json \
+--data ./input.resource.json
+```
+
+Find the order ID in the output, for example:
+
+```
+Workflow was created, TEE order id: ["275510"]
+```
+
+### 4. Download the result
+
+Replace `275510` with your order ID:
+
+```shell
+./spctl orders download-result 275510
+```
+
+If there is no result for your order yet, wait a couple of minutes and try again.
+
+Find `output/result.txt` inside the downloaded archive `result.tar.gz`.
+
+## Support
+
+If you have any issues or questions, contact Super Protocol on [Discord](https://discord.gg/superprotocol) or via the [contact form](https://superprotocol.zendesk.com/hc/en-us/requests/new).

--- a/docs/cli/Guides/deploy-app/index.md
+++ b/docs/cli/Guides/deploy-app/index.md
@@ -1,7 +1,7 @@
 ---
-id: "quick-guide"
+id: "deploy-app"
 title: "Deploy Your App"
-slug: "/guides/quick-guide"
+slug: "/guides/deploy-app"
 sidebar_position: 2
 ---
 
@@ -18,13 +18,13 @@ This quick guide provides instructions on deploying your own <a id="solution"><s
 
 When writing a Dockerfile and other scripts, keep in mind the special file structure inside the <a id="tee"><span className="dashed-underline">TEE</span></a>:
 
-| **Location**                                                      | **Purpose**                                                   | **Access** |
+| <div style={{width:190}}>**Location**</div>                       | **Purpose**                                                   | <div style={{width:120}}>**Access**</div> |
 | :-                                                                | :-                                                            | :- |
-| `/sp/inputs/input-0001`<br/>`/sp/inputs/input-0002`<br/>etc.      | Possible data locations                                       | Read-only |
-| `/sp/output`                                                      | Output directory for results                                  | Write; read own files |
+| `/sp/inputs/input-0001`<br/>`/sp/inputs/input-0002`<br/>...       | Possible data locations                                       | Read-only |
+| `/sp/output`                                                      | Output directory for results                                  | Read and write |
 | `/sp/certs`                                                       | Contains the order certificate, private key, and workloadInfo | Read-only |
 
-So, your solution must find the data in `/sp/inputs` and write the results to `/sp/output`.
+When you provide multiple data inputs, they are placed in separate directories inside the <a id="cvm"><span className="dashed-underline">CVM</span></a>: the first in `/sp/inputs/input-0001`, the second in `/sp/inputs/input-0002`, and so on. Your solution must find the data in `/sp/inputs` and write the results to `/sp/output`.
 
 :::important
 
@@ -32,7 +32,9 @@ Always use absolute paths, such as `/sp/...`.
 
 :::
 
-You can find several Dockerfile examples in the [Super-Protocol/solutions](https://github.com/Super-Protocol/solutions) GitHub repository.
+Check the [example](/cli/guides/deploy-app/example) at the end of this guide.
+
+More Dockerfile examples can be found in the [Super-Protocol/solutions](https://github.com/Super-Protocol/solutions) GitHub repository.
 
 ### 1.2. Build a Docker image
 
@@ -124,17 +126,11 @@ Place an order using the [`workflows create`](/cli/commands/workflows/create) co
 --data ./more-data.resource.json
 ```
 
-:::note
-
-When you provide multiple data inputs, they are placed in separate directories inside the <a id="cvm"><span className="dashed-underline">CVM</span></a>: the first in `/sp/inputs/input-0001`, the second in `/sp/inputs/input-0002`, and so on.
-
-:::
-
 Find the order ID in the output.
 
 ## 4. Download the result
 
-Wait a few minutes and [check the order status](/cli/commands/orders/get):
+Wait a few minutes and check the order status:
 
 ```shell
 ./spctl orders get <ORDER_ID>
@@ -146,7 +142,7 @@ For example:
 ./spctl orders get 256587
 ```
 
-If the status is `Done`, the order is ready, and you can [download the order result](/cli/commands/orders/download-result):
+If the status is `Done` or `Error`, you can [download the order result](/cli/commands/orders/download-result):
 
 ```shell
 ./spctl orders download-result <ORDER_ID>

--- a/docs/cli/Guides/tgwui.md
+++ b/docs/cli/Guides/tgwui.md
@@ -151,7 +151,7 @@ Your model's web UI will be available at this URL.
         }
         ```
     </TabItem>
-    <TabItem value="comfyui" label="ComfyUI" default>
+    <TabItem value="comfyui" label="ComfyUI">
         Create a file named `engine-configuration-comfyui.json` and paste the following:
 
         ```json title="engine-configuration-comfyui.json"
@@ -198,7 +198,7 @@ Save and close the file.
 
         Note that `--solution 25` refers to [Text Generation Web UI with GPU support](https://marketplace.superprotocol.com/marketplace/models?offer=offerId%3D25). If you need the CPU version, use `--solution 26` instead.
     </TabItem>
-    <TabItem value="comfyui" label="ComfyUI" default>
+    <TabItem value="comfyui" label="ComfyUI">
 
         ```shell
         ./spctl workflows create --tee <COMPUTE_OFFER> --solution 27 --solution-configuration ./engine-configuration-comfyui.json --data ./model.resource.json

--- a/docs/cli/Guides/tgwui.md
+++ b/docs/cli/Guides/tgwui.md
@@ -12,7 +12,7 @@ This guide provides step-by-step instructions for uploading and deploying an AI 
 
 ## Prerequisites
 
-- [SPCTL](https://docs.develop.superprotocol.com/cli/)
+- [SPCTL](/cli/)
 - BNB and SPPI tokens (opBNB) to pay for transactions and orders
 
 ## 1. Prepare
@@ -91,19 +91,20 @@ Replace `<ORDER_ID>` with the tunnel order ID from the previous step.
 ./spctl orders download-result <ORDER_ID>
 ```
 
-3.5. Extract the downloaded `result.tar.gz`, open `output/result.json`, and find the domain address. For example:
+3.5. Extract the downloaded `result.tar.gz`, open `output/result.json`, and find the domain. For example:
 
 ```json title="result.json"
 "domain":"pret-tons-wade.superprotocol.io"
 ```
 
-Your model's web UI will be available at this address.
+Your model's web UI will be available at this URL.
 
 ## 4. Prepare engine configuration files
 
 4.1. Open the SPCTL's `config.json` and find the `workflow.resultEncryption.key` property that contains the key used for decrypting workflow results; for example: `NapSrwQRz2tL9ZftJbi6DATpCDn0BRImpSStU9xZT/s=`.
 
-4.2.
+4.2. Create configuration files:
+
 <Tabs>
     <TabItem value="tgwui" label="TGWUI" default>
         Create a file named `engine-configuration-tgwui.json` and paste the following:
@@ -184,10 +185,10 @@ Save and close the file.
 
 ## 5. Deploy the model
 
-5.1.
+5.1. Create the main order to deploy your uploaded model:
+
 <Tabs>
     <TabItem value="tgwui" label="TGWUI" default>
-        Create the main order to deploy your uploaded model:
 
         ```shell
         ./spctl workflows create --tee <COMPUTE_OFFER> --solution 25 --solution-configuration ./engine-configuration-tgwui.json --data ./model.resource.json
@@ -198,7 +199,6 @@ Save and close the file.
         Note that `--solution 25` refers to [Text Generation Web UI with GPU support](https://marketplace.superprotocol.com/marketplace/models?offer=offerId%3D25). If you need the CPU version, use `--solution 26` instead.
     </TabItem>
     <TabItem value="comfyui" label="ComfyUI" default>
-        Create the main order to deploy your uploaded model:
 
         ```shell
         ./spctl workflows create --tee <COMPUTE_OFFER> --solution 27 --solution-configuration ./engine-configuration-comfyui.json --data ./model.resource.json

--- a/docs/cli/Guides/unsloth.md
+++ b/docs/cli/Guides/unsloth.md
@@ -7,11 +7,11 @@ sidebar_position: 5
 
 This guide provides step-by-step instructions for fine-tuning an AI model using the Super Protocol packaging of [Unsloth](https://unsloth.ai/), an open-source framework for LLM fine-tuning and reinforcement learning.
 
-The <a id="solution"><span className="dashed-underline">solution</span></a> allows you to run fine-tuning within Super Protocol's Trusted Execution Environment (TEE). This provides enhanced security and privacy and enables a range of [confidential collaboration](https://docs.develop.superprotocol.com/cli/guides/multi-party-collab) scenarios.
+The <a id="solution"><span className="dashed-underline">solution</span></a> allows you to run fine-tuning within Super Protocol's Trusted Execution Environment (TEE). This provides enhanced security and privacy and enables a range of [confidential collaboration](/cli/guides/multi-party-collab) scenarios.
 
 ## Prerequisites
 
-- [SPCTL](https://docs.develop.superprotocol.com/cli/)
+- [SPCTL](/cli/)
 - Git
 - BNB and SPPI tokens (opBNB) to pay for transactions and orders
 

--- a/docs/cli/Guides/vllm.md
+++ b/docs/cli/Guides/vllm.md
@@ -9,7 +9,7 @@ This guide provides step-by-step instructions for running an AI model inference 
 
 ## Prerequisites
 
-- [SPCTL](https://docs.develop.superprotocol.com/cli/)
+- [SPCTL](/cli/)
 - Git
 - BNB and SPPI tokens (opBNB) to pay for transactions and orders
 

--- a/docs/fundamentals/certification.md
+++ b/docs/fundamentals/certification.md
@@ -28,7 +28,7 @@ The Certification System is organized as a hierarchy of <a id="ca"><span classNa
 
 The chain consists of three levels:
 
-- Root CA is the top-level certificate authority that establishes the trust anchor for the entire system. At the start, it generates a self-signed certificate, embedding the SGX attestation quote.
+- Root CA is the top-level certificate authority that establishes the trust anchor for the entire system. At the start, it generates a self-signed certificate that embeds the SGX attestation quote.
 - SubRoot CAs are intermediate certificate authorities. They submit their quotes and public keys to the Root CA and request certificates. The Root CA verifies these incoming requests and then issues and signs certificates for the SubRoot CAs. Once a SubRoot CA is certified by the Root CA, it can certify any TEE-backed environment that proves it is actually confidential.
 - End certificates are issued to specific workloads, entire <a id="ca"><span className="dashed-underline">Confidential Virtual Machines</span></a> (CVMs) running in TEEs, and in some other cases. These certificates are not CAs and cannot be used to sign or issue other certificates.
 
@@ -36,7 +36,7 @@ Each level in the hierarchy receives its certificate from the level above, creat
 
 ## Trusted Loader
 
-Trusted Loader is a special service that prepares and launches the workload associated with an <a id="order"><span className="dashed-underline">order</span></a> inside a CVM running in a TEE. It runs in a privileged position within the execution environment, allowing it to access the underlying attestation capabilities of the platform. Workloads themselves do not have such access.
+Trusted Loader is a special service that prepares and launches the workload associated with an <a id="order"><span className="dashed-underline">order</span></a> inside a CVM running in a TEE. Loader occupies a privileged position within the execution environment, enabling it to access the platform's underlying attestation capabilities. Workloads themselves do not have such access.
 
 Trusted Loader also:
 
@@ -63,7 +63,7 @@ Note that the Certification System does not determine whether a CVM is correct o
 
 Orders in Super Protocol are created with a workload description known as *Workload Info*.
 
-Workload Info includes an array called `runtimeInfo`. It contains information about <a id="solution"><span className="dashed-underline">solutions</span></a> and <a id="data"><span className="dashed-underline">data</span></a> associated with the order. Each such order component has an entry in this array, which includes:
+Workload Info includes an array called `runtimeInfo` that contains information about <a id="solution"><span className="dashed-underline">solutions</span></a> and <a id="data"><span className="dashed-underline">data</span></a> associated with the order. Each data and solution component of the order has an entry in this array, which includes:
 
 - Type (solution or data)
 - Hash

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -18,12 +18,12 @@ sidebar_position: 0
 
 ## CLI
 
-| <div style={{width:215}}>**Guide**</div>                  | <div style={{width:550}}>**Description**</div> |
-| :-                                                        | :- |
-| [Configure SPCTL](/cli)                                   | How to set up SPCTL—a Super Protocol CLI tool. |
-| [Configure Provider Tools](/cli/guides/provider-tools)    | How to set up Provider Tools—a Super Protocol CLI utility for registering <a id="provider"><span className="dashed-underline">providers</span></a> and creating <a id="offer"><span className="dashed-underline">offers</span></a>. |
-| [Quick Deployment Guide](/cli/guides/quick-guide)         | Quick instructions on deploying a <a id="solution"><span className="dashed-underline">solution</span></a> and <a id="data"><span className="dashed-underline">data</span></a> on Super Protocol. |
-| [Confidential Collaboration](/cli/guides/multi-party-collab)       | A scenario of confidential collaboration on Super Protocol. |
+| <div style={{width:215}}>**Guide**</div>                      | <div style={{width:550}}>**Description**</div> |
+| :-                                                            | :- |
+| [Configure SPCTL](/cli)                                       | How to set up SPCTL—a Super Protocol CLI tool. |
+| [Configure Provider Tools](/cli/guides/provider-tools)        | How to set up Provider Tools—a Super Protocol CLI utility for registering <a id="provider"><span className="dashed-underline">providers</span></a> and creating <a id="offer"><span className="dashed-underline">offers</span></a>. |
+| [Quick Deployment Guide](/cli/guides/deploy-app)              | Quick instructions on deploying a <a id="solution"><span className="dashed-underline">solution</span></a> and <a id="data"><span className="dashed-underline">data</span></a> on Super Protocol. |
+| [Confidential Collaboration](/cli/guides/multi-party-collab)  | A scenario of confidential collaboration on Super Protocol. |
 
 ### Solutions
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -42,10 +42,10 @@ const config = {
             from: "/hackathon",
             to: "/hackathon/about",
           },
-          /*{
-            from: "/colab",
-            to: "/colab/jupyter",
-          },*/
+          {
+            from: "/cli/guides/quick-guide",
+            to: "/cli/guides/deploy-app",
+          },
         ],
       },
     ],

--- a/static/files/usd_to_crypto.py
+++ b/static/files/usd_to_crypto.py
@@ -1,0 +1,45 @@
+import requests
+import sys
+
+def main():
+    input_file = "input.txt"
+    output_file = "result.txt"
+
+    try:
+        # Read the input amount
+        with open(input_file, "r") as f:
+            content = f.read().strip()
+        if not content:
+            raise ValueError("Input file is empty")
+
+        try:
+            usd_amount = float(content)
+        except ValueError:
+            raise ValueError("Input is not a valid number")
+
+        # Fetch BTC and ETH prices from CoinGecko
+        url = "https://api.coingecko.com/api/v3/simple/price?ids=bitcoin,ethereum&vs_currencies=usd"
+        response = requests.get(url, timeout=10)
+        if response.status_code != 200:
+            raise RuntimeError(f"API request failed with status code {response.status_code}")
+
+        data = response.json()
+        btc_price = data["bitcoin"]["usd"]
+        eth_price = data["ethereum"]["usd"]
+
+        # Calculate how much BTC and ETH can be bought
+        btc_amount = usd_amount / btc_price
+        eth_amount = usd_amount / eth_price
+
+        # Write results to output file, rounded to 6 decimals
+        with open(output_file, "w") as f:
+            f.write(f"BTC: {btc_amount:.6f}\n")
+            f.write(f"ETH: {eth_amount:.6f}\n")
+
+    except Exception as e:
+        # Write the error message to the result file
+        with open(output_file, "w") as f:
+            f.write(f"Error: {str(e)}\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a step-by-step guide for deploying Python apps using the CLI, including packaging, deployment, and result retrieval.
  * Updated CLI guides with clearer paths, examples, JSON configuration samples, and improved internal links and redirects.
  * Clarified data path semantics and result download conditions.
  * Refined platform certification/attestation wording for clarity.
  * Added an example Python script demonstrating a cryptocurrency price conversion workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->